### PR TITLE
Feature/order api

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,5 +228,23 @@ PRODUCT ||--o{ PAYMENT : bought
       <td>Admin</td>
       <td>결재 내역을 삭제합니다.</td>
     </tr>
+    <tr>
+      <td rowspan=3>Order</td>
+      <td>GET</td>
+      <td rowspan=2>/api/v1/orders/</td>
+      <td>Admin</td>
+      <td>주문 내역을 불러옵니다.</td>
+    </tr>
+    <tr>
+      <td>POST</td>
+      <td>LoggedIn</td>
+      <td>상품을 주문합니다.</td>
+    </tr>
+    <tr>
+      <td>PATCH</td>
+      <td>/api/v1/orders/{id}/</td>
+      <td>LoggedIn</td>
+      <td>주문 상태를 변경합니다.</td>
+    </tr>
   </tbody>
 </table>

--- a/orders/permissions.py
+++ b/orders/permissions.py
@@ -1,0 +1,8 @@
+from rest_framework.permissions import BasePermission
+
+
+class OrderPermission(BasePermission):
+    def has_permission(self, request, view):
+        if request.method == "GET":
+            return request.user and request.user.is_staff
+        return True

--- a/orders/permissions.py
+++ b/orders/permissions.py
@@ -4,5 +4,5 @@ from rest_framework.permissions import BasePermission
 class OrderPermission(BasePermission):
     def has_permission(self, request, view):
         if request.method == "GET":
-            return request.user and request.user.is_staff
-        return True
+            return bool(request.user and request.user.is_staff)
+        return bool(request.user and request.user.is_authenticated)

--- a/orders/serializers.py
+++ b/orders/serializers.py
@@ -14,6 +14,7 @@ class OrderSerializer(serializers.ModelSerializer):
             "id",
             "created_at",
             "status",
+            "delivery_address",
             "products",
             "user",
             "payment",

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path("", views.OrdersView.as_view()),
+    path("<int:pk>", views.OrderView.as_view()),
 ]

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -3,5 +3,5 @@ from . import views
 
 urlpatterns = [
     path("", views.OrdersView.as_view()),
-    path("<int:pk>", views.OrderView.as_view()),
+    path("<int:pk>/", views.OrderView.as_view()),
 ]

--- a/orders/views.py
+++ b/orders/views.py
@@ -1,13 +1,17 @@
+from django.db import transaction
 from rest_framework.views import APIView
-from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
+from rest_framework.status import HTTP_400_BAD_REQUEST
+from rest_framework.exceptions import ParseError
 from .models import Order
+from products.models import Product
 from .serializers import OrderSerializer
+from .permissions import OrderPermission
 
 
 class OrdersView(APIView):
 
-    permission_classes = [IsAdminUser]
+    permission_classes = [OrderPermission]
 
     def get(self, request):
         """
@@ -18,3 +22,34 @@ class OrdersView(APIView):
         orders = Order.objects.all()
         serializer = OrderSerializer(orders, many=True)
         return Response(serializer.data)
+
+    def post(self, request):
+        """
+        상품 주문
+        POST /api/v1/orders/
+        """
+
+        serializer = OrderSerializer(data=request.data)
+        products = request.data.get("products")
+
+        if not products:
+            raise ParseError("products is required.")
+
+        if serializer.is_valid():
+            try:
+                with transaction.atomic():
+                    order = serializer.save(
+                        user=request.user,
+                        status=Order.OrderStatusChoices.PAYED,
+                    )
+
+                    products = request.data.get("products")
+                    for product_pk in products:
+                        product = Product.objects.get(pk=product_pk)
+                        order.products.add(product)
+
+                    serializer = OrderSerializer(order)
+                    return Response(serializer.data)
+            except Exception:
+                raise ParseError("not valid product id.")
+        return Response(serializer.errors, status=HTTP_400_BAD_REQUEST)

--- a/orders/views.py
+++ b/orders/views.py
@@ -78,13 +78,13 @@ class OrderView(APIView):
         order = self.get_object(pk)
 
         # 주문자가 상품을 배송 받은 경우
-        if order.user == request.user:
+        if order.user == request.user and order.status == Order.OrderStatusChoices.SENT:
             order.status = Order.OrderStatusChoices.ARRIVED
             order.save()
             return Response(status=HTTP_200_OK)
 
         # 주문자가 상품을 발송한 경우
-        if request.user.is_staff:
+        if request.user.is_staff and order.status == Order.OrderStatusChoices.PAYED:
             order.status = Order.OrderStatusChoices.SENT
             order.save()
             return Response(status=HTTP_200_OK)

--- a/orders/views.py
+++ b/orders/views.py
@@ -1,8 +1,8 @@
 from django.db import transaction
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.status import HTTP_400_BAD_REQUEST
-from rest_framework.exceptions import ParseError
+from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_200_OK
+from rest_framework.exceptions import ParseError, NotFound
 from .models import Order
 from products.models import Product
 from .serializers import OrderSerializer
@@ -38,6 +38,9 @@ class OrdersView(APIView):
         if serializer.is_valid():
             try:
                 with transaction.atomic():
+                    # TODO: 결제 관련 & 결제 검증 로직 추가
+                    # ...
+
                     order = serializer.save(
                         user=request.user,
                         status=Order.OrderStatusChoices.PAYED,
@@ -53,3 +56,33 @@ class OrdersView(APIView):
             except Exception:
                 raise ParseError("not valid product id.")
         return Response(serializer.errors, status=HTTP_400_BAD_REQUEST)
+
+
+class OrderView(APIView):
+    def get_object(self, pk):
+        try:
+            return Order.objects.get(pk=pk)
+        except Order.DoesNotExist:
+            raise NotFound
+
+    def patch(self, request, pk):
+        """
+        주문 내역 상태 변경
+        PATCH /api/v1/orders/{id}/
+        """
+
+        order = self.get_object(pk)
+
+        # 주문자가 상품을 배송 받은 경우
+        if order.user == request.user:
+            order.status = Order.OrderStatusChoices.ARRIVED
+            order.save()
+            return Response(status=HTTP_200_OK)
+
+        # 주문자가 상품을 발송한 경우
+        if request.user.is_staff:
+            order.status = Order.OrderStatusChoices.SENT
+            order.save()
+            return Response(status=HTTP_200_OK)
+
+        return Response(status=HTTP_400_BAD_REQUEST)

--- a/orders/views.py
+++ b/orders/views.py
@@ -3,6 +3,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_200_OK
 from rest_framework.exceptions import ParseError, NotFound
+from rest_framework.permissions import IsAuthenticated
 from .models import Order
 from products.models import Product
 from .serializers import OrderSerializer
@@ -59,6 +60,9 @@ class OrdersView(APIView):
 
 
 class OrderView(APIView):
+
+    permission_classes = [IsAuthenticated]
+
     def get_object(self, pk):
         try:
             return Order.objects.get(pk=pk)


### PR DESCRIPTION
## 변경 사항
- 상품 주문 API
- 상품 주문 상태 변경 API

상품 주문과 상품 주문의 상태를 변경하는 API를 추가하였습니다.
상품 주문은 로그인된 유저에게 권한을 허용하였고, status를 임의로 변경하는 것을 막기 위해 `payed`로 고정하였습니다.
제대로된 `product_pk`를 받지 않았다면 rollback을 위하여 `transaction`을 사용하였습니다.
결제 관련 검증에 대해서는 과제 범위를 벗어나는 것으로 TODO로 남겨두었습니다.

주문 내역 상태 변경은 Request의 주체가 관리자이면 관리자가 백오피스에서 상품 배송완료 버튼을 클릭한다고 가정하고, `status`를 `sent`로 변경되게 구현하였고 주문을 한 유저이면 구매확정 버튼을 누른다는 느낌으로 `status`를 `arrived`로 변경되게 구현하였습니다.

환불 및 결제 취소는 해당 api가 아닌 따로 구현한 후 변경되어야하기 때문에 해당 api에서 구현하지 않았습니다.